### PR TITLE
Multiple Definition Problem

### DIFF
--- a/src/metawear/core/metawearboard.h
+++ b/src/metawear/core/metawearboard.h
@@ -16,7 +16,7 @@
 #include "metawear/platform/dllmarker.h"
 
 /** Constant signifying a module is not available */
-const int32_t MBL_MW_MODULE_TYPE_NA = -1;
+extern const int32_t MBL_MW_MODULE_TYPE_NA;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/metawear/impl/cpp/metawearboard.cpp
+++ b/src/metawear/impl/cpp/metawearboard.cpp
@@ -58,6 +58,7 @@
 using namespace std;
 using namespace std::chrono;
 
+const int32_t MBL_MW_MODULE_TYPE_NA = -1;
 const uint8_t CARTESIAN_FLOAT_SIZE= 6;
 const uint16_t MAX_TIME_PER_RESPONSE= 4000;
 


### PR DESCRIPTION
When the header metawearboard.h is included by different sources of a follow-up project, then the definition of the constant MBL_MW_MODULE_TYPE_NA inside the header can lead to multiple definition errors at the linker stage. Please move the definition of the constant into the source file and in the header declare the constant MBL_MW_MODULE_TYPE_NA as extern. Thank you.