### PR TITLE
specified namespace std of size_t to correct build errors

### DIFF
--- a/src/metawear/sensor/cpp/utils.cpp
+++ b/src/metawear/sensor/cpp/utils.cpp
@@ -31,7 +31,7 @@ uint8_t closest_index(const vector<float>& values, float key) {
     return closest_index(values.data(), values.size(), key);
 }
 
-uint8_t closest_index(const float* values, size_t len, float key) {
+uint8_t closest_index(const float* values, std::size_t len, float key) {
     vector<float> differences;
     differences.resize(len);
 

--- a/src/metawear/sensor/cpp/utils.h
+++ b/src/metawear/sensor/cpp/utils.h
@@ -7,4 +7,4 @@ char* copy_string_index(const char* src, std::uint8_t i);
 char* copy_string(const char* src);
 
 uint8_t closest_index(const std::vector<float>& values, float key);
-uint8_t closest_index(const float* values, size_t len, float key);
+uint8_t closest_index(const float* values, std::size_t len, float key);


### PR DESCRIPTION
This corrects compiler errors complaining about missing definition for size_t