### PR TITLE
fixed build for g++ by modifying catch exception

### DIFF
--- a/src/metawear/core/cpp/datasignal.cpp
+++ b/src/metawear/core/cpp/datasignal.cpp
@@ -224,7 +224,7 @@ void MblMwDataSignal::make_unsigned() {
 MblMwDataSignal* mbl_mw_datasignal_get_component(const MblMwDataSignal* signal, uint8_t index) {
     try {
         return signal->components.at(index);
-    } catch (out_of_range) {
+    } catch (out_of_range&) {
         return nullptr;
     }
 }

--- a/src/metawear/impl/cpp/metawearboard.cpp
+++ b/src/metawear/impl/cpp/metawearboard.cpp
@@ -155,7 +155,7 @@ static int32_t forward_response(const ResponseHeader& header, MblMwMetaWearBoard
         }
 
         return handled ? MBL_MW_STATUS_OK : MBL_MW_STATUS_WARNING_UNEXPECTED_SENSOR_DATA;
-    } catch (exception) {
+    } catch (exception&) {
         return MBL_MW_STATUS_WARNING_UNEXPECTED_SENSOR_DATA;
     }
 }
@@ -190,7 +190,7 @@ int32_t response_handler_packed_data(MblMwMetaWearBoard *board, const uint8_t *r
         }
 
         return MBL_MW_STATUS_OK;
-    } catch (exception) {
+    } catch (exception&) {
         return MBL_MW_STATUS_WARNING_UNEXPECTED_SENSOR_DATA;
     }
 }
@@ -538,7 +538,7 @@ int32_t mbl_mw_metawearboard_lookup_module(const MblMwMetaWearBoard *board, MblM
             return board->module_info.at(module).implementation;
         }
         return MBL_MW_MODULE_TYPE_NA;
-    } catch (exception) {
+    } catch (exception&) {
         return MBL_MW_MODULE_TYPE_NA;
     }
 }

--- a/src/metawear/sensor/cpp/multichanneltemperature.cpp
+++ b/src/metawear/sensor/cpp/multichanneltemperature.cpp
@@ -43,7 +43,7 @@ void mbl_mw_multi_chnl_temp_configure_ext_thermistor(const MblMwMetaWearBoard *b
 MblMwTemperatureSource mbl_mw_multi_chnl_temp_get_source(const MblMwMetaWearBoard *board, uint8_t channel) {
     try {
         return (MblMwTemperatureSource) board->module_info.at(MBL_MW_MODULE_TEMPERATURE).extra.at(channel);
-    } catch (out_of_range) {
+    } catch (out_of_range&) {
         return MBL_MW_TEMPERATURE_SOURCE_INVALID;
     }
 }


### PR DESCRIPTION
I was having some problems building the Metawar SDK. I fixed the build with these minor changes to how exceptions are handled. 

```
g++ -MMD -MP -MF "build/x64/release/src/metawear/core/cpp/datasignal.d" -c -o build/x64/release/src/metawear/core/cpp/datasignal.o -std=c++11 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Werror -Isrc -DMETAWEAR_DLL -DMETAWEAR_DLL_EXPORTS  -O3 -m64 src/metawear/core/cpp/datasignal.cpp
src/metawear/core/cpp/datasignal.cpp: In function ‘MblMwDataSignal* mbl_mw_datasignal_get_component(const MblMwDataSignal*, uint8_t)’:
src/metawear/core/cpp/datasignal.cpp:227:14: error: catching polymorphic type ‘class std::out_of_range’ by value [-Werror=catch-value=]
     } catch (out_of_range) {
              ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make: *** [Makefile:65: build/x64/release/src/metawear/core/cpp/datasignal.o] Error 1
```
g++ (GCC) 8.1.1 20180531
