### PR TITLE
only differentiate epoch calculation for accounter types

### DIFF
--- a/src/metawear/impl/cpp/metawearboard.cpp
+++ b/src/metawear/impl/cpp/metawearboard.cpp
@@ -83,9 +83,10 @@ static int64_t extract_accounter_epoch(MblMwDataProcessor* processor, int64_t or
     // API that works off of the base clock and call get_accounter_prescale(processor);
     memcpy(tick, *start, timestampLength);
 
+    (*start) += timestampLength;
+    len -= timestampLength;
+
     if (get_accounter_type(processor) == ACCOUNTER_TIME) {
-        (*start) += timestampLength;
-        len -= timestampLength;
         return calculate_epoch(processor->owner, *tick);
     }
 


### PR DESCRIPTION
  - not modifying the pointers in extract_accounter_epoch for
  ACCOUNTER_COUNT breaks the data envelopes in the fuser dataprocessor