### PR TITLE
fix: favor snprintf over insecure sprintf

### DIFF
--- a/MetaWear.Win32.vcxproj
+++ b/MetaWear.Win32.vcxproj
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectName>MetaWear.Win32</ProjectName>
     <RootNamespace>MetaWear.Win32</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup>
@@ -36,7 +36,7 @@
     <UseDebugLibraries Condition="'$(Configuration)'=='Debug'">true</UseDebugLibraries>
     <UseDebugLibraries Condition="'$(Configuration)'=='Release'">false</UseDebugLibraries>
     <WholeProgramOptimization Condition="'$(Configuration)'=='Release'">true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -84,16 +84,11 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <UsingTask TaskName="SetEnv" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.CppTasks.Common.dll"/>
+  <UsingTask TaskName="SetEnv" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.Build.CppTasks.Common.dll" />
   <Target Name="Test" DependsOnTargets="Build">
-    <SetEnv Name   ="METAWEAR_LIB_SO_NAME"
-            Value  ="$(TargetPath)"
-            Prefix ="false">
+    <SetEnv Name="METAWEAR_LIB_SO_NAME" Value="$(TargetPath)" Prefix="false">
     </SetEnv>
-
-    <SetEnv Name   ="PYTHONPATH"
-            Value  ="bindings\python"
-            Prefix ="false">
+    <SetEnv Name="PYTHONPATH" Value="bindings\python" Prefix="false">
     </SetEnv>
     <Exec Command="python -m unittest discover -s test" />
   </Target>

--- a/MetaWear.Win32.vcxproj.user
+++ b/MetaWear.Win32.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/src/metawear/dfu/cpp/file_operations.cpp
+++ b/src/metawear/dfu/cpp/file_operations.cpp
@@ -124,11 +124,12 @@ void FileOperations::openZip(const char *filename)
                 if (it1 != it->end()) {
                     auto it2 = it1->find("bin_file");
                     if (it2 != it1->end()) {
-                        firmwareFilename = *it2;
+                        firmwareFilename = static_cast<std::string const&>(*it2);
                     }
+
                     auto it3 = it1->find("dat_file");
                     if (it3 != it1->end()) {
-                        metadataFilename = *it3;
+                        metadataFilename = static_cast<std::string const&>(*it3);
                     }
                 }
             }

--- a/src/metawear/impl/cpp/datainterpreter.cpp
+++ b/src/metawear/impl/cpp/datainterpreter.cpp
@@ -288,7 +288,7 @@ static MblMwData* convert_to_mac_address(bool log_data, const MblMwDataSignal* s
     const int strSize = 17 + 1;
     const uint8_t offset = len == 7 ? 1 : 0;
     char *value = (char *)malloc(strSize);
-    sprintf(value, "%02X:%02X:%02X:%02X:%02X:%02X", response[5 + offset], response[4 + offset], 
+    snprintf(value, strSize,"%02X:%02X:%02X:%02X:%02X:%02X", response[5 + offset], response[4 + offset], 
         response[3 + offset], response[2 + offset], response[1 + offset], response[0 + offset]);
     value[strSize - 1] = '\0';
 

--- a/src/metawear/sensor/cpp/utils.cpp
+++ b/src/metawear/sensor/cpp/utils.cpp
@@ -9,7 +9,7 @@
 using std::distance;
 using std::fabs;
 using std::min_element;
-using std::sprintf;
+using std::snprintf;
 using std::strcpy;
 using std::strlen;
 using std::transform;
@@ -17,7 +17,7 @@ using std::vector;
 
 char* copy_string_index(const char* src, std::uint8_t i) {
     char* buffer = (char*)std::malloc(strlen(src) + 6);
-    sprintf(buffer, "%s[%d]", src, i);
+    snprintf(buffer, strlen(src) + 6, "%s[%d]", src, i);
     return buffer;
 }
 


### PR DESCRIPTION
When building with clang and warnings, I bumped into a warning about a potential buffer overflow. 

This is easily mitigated by changing to snprintf.